### PR TITLE
fix: crash when context is called too early

### DIFF
--- a/CardSleeves.lua
+++ b/CardSleeves.lua
@@ -2032,7 +2032,7 @@ function SMODS.get_card_areas(_type, _context)
             end
             output[#output+1] = {
                 object = fake_sleeve,
-                scored_card = G.deck.cards[1] or G.deck,
+                scored_card = G.deck and G.deck.cards[1] or G.deck,
             }
         end
     end


### PR DESCRIPTION
Happens when starting a new run with the new SMODS weights optional feature (I think only when starting a run in the middle of another?)

This just adds the same nil check SMODS already has in SMODS.get_card_areas