### PR TITLE
Fix orphaned text

### DIFF
--- a/CardSleeves.lua
+++ b/CardSleeves.lua
@@ -1467,12 +1467,13 @@ local function handle_collection_click(card, direction)
     end
 end
 
-local function get_sleeve_name_text(sleeve_center)
+local function get_sleeve_name_text(sleeve_center, args)
+    args = args or {}
     local loc_vars = {}
     if sleeve_center.loc_vars and type(sleeve_center.loc_vars) == 'function' then
         loc_vars = sleeve_center:loc_vars() or {}
     end
-    return localize { type = 'name_text', key = loc_vars.name_key or sleeve_center.key, set = loc_vars.name_set or sleeve_center.set }
+    return localize { type = 'name_text', key = args.key or loc_vars.name_key or sleeve_center.key, set = args.set or loc_vars.name_set or sleeve_center.set }
 end
 
 --#endregion
@@ -1555,7 +1556,7 @@ function G.UIDEF.sleeve_description(sleeve_key, minw, padding)
     minw = minw or 5.5
     padding = padding or 0
     local sleeve_center = CardSleeves.Sleeve:get_obj(sleeve_key)
-    local ret_nodes, full_UI_table = {}, {}
+    local ret_nodes, full_UI_table = {}, {no_styled_name = true}
     local sleeve_name = ""
     if sleeve_center then
         sleeve_center.generate_ui(create_fake_sleeve(sleeve_center), {}, nil, ret_nodes, nil, full_UI_table)

--- a/CardSleeves.lua
+++ b/CardSleeves.lua
@@ -1466,6 +1466,15 @@ local function handle_collection_click(card, direction)
         end
     end
 end
+
+local function get_sleeve_name_text(sleeve_center)
+    local loc_vars = {}
+    if sleeve_center.loc_vars and type(sleeve_center.loc_vars) == 'function' then
+        loc_vars = sleeve_center:loc_vars() or {}
+    end
+    return localize { type = 'name_text', key = loc_vars.name_key or sleeve_center.key, set = loc_vars.name_set or sleeve_center.set }
+end
+
 --#endregion
 
 --#region GLOBAL (used in UI) FUNCS
@@ -1849,16 +1858,13 @@ function G.UIDEF.challenge_description_tab(args)
         local challenge = G.CHALLENGES[args._id]
         if challenge.sleeve then
             local sleeve_center = CardSleeves.Sleeve:get_obj(challenge.sleeve)
-            local ret_nodes, full_UI_table = {}, {}
-            sleeve_center.generate_ui(create_fake_sleeve(sleeve_center), {}, nil, ret_nodes, nil, full_UI_table)
-            local sleeve_name = full_UI_table.name or ret_nodes.name
             local UI_node = {
                 n = G.UIT.R,
                 config = {align = "cl", maxw = 3.5},
                 nodes = localize {
                     type = "text",
                     key = "ch_m_sleeve",
-                    vars = {sleeve_name},
+                    vars = {get_sleeve_name_text(sleeve_center)},
                     default_col = G.C.L_BLACK
                 }
             }
@@ -2391,10 +2397,7 @@ if Galdur then
 
     local function set_sleeve_text(sleeve_center)
         -- sets deck name to sleeve name in Galdur's deck preview
-        local ret_nodes, full_UI_table = {}, {}
-        sleeve_center.generate_ui(create_fake_sleeve(sleeve_center), {}, nil, ret_nodes, nil, full_UI_table)
-        local sleeve_name = full_UI_table.name or ret_nodes.name
-        local texts = split_string_2(sleeve_name)
+        local texts = split_string_2(get_sleeve_name_text(sleeve_center))
         if Galdur.deck_preview_texts then
             Galdur.deck_preview_texts.deck_preview_1 = texts[1]
             Galdur.deck_preview_texts.deck_preview_2 = texts[2]
@@ -2414,10 +2417,7 @@ if Galdur then
         end
         local sleeve_center = CardSleeves.Sleeve:get_obj(quick_start_sleeve)
         if sleeve_center then
-            local ret_nodes, full_UI_table = {}, {}
-            sleeve_center.generate_ui(create_fake_sleeve(sleeve_center), {}, nil, ret_nodes, nil, full_UI_table)
-            local sleeve_name = full_UI_table.name or ret_nodes.name
-            return sleeve_name
+            return get_sleeve_name_text(sleeve_center)
         else
             return "ERROR"
         end

--- a/CardSleeves.lua
+++ b/CardSleeves.lua
@@ -2198,7 +2198,7 @@ function Card:hover()
             end
             local info_queue = result
             for _, center in pairs(info_queue) do
-                local desc = generate_card_ui(center, {main = {},info = {},type = {},name = 'done'}, nil, center.set, nil)
+                local desc = generate_card_ui(center, {main = {},info = {},type = {},name = 'done', from_detailed_tooltip = true}, nil, center.set, nil)
                 tooltips[#tooltips + 1] =
                 {n=info_col, config={align = self.params.sleeve_select > sleeve_count_horizontal and "bm" or "tm"}, nodes={
                     {n=G.UIT.R, config={align = "cm", colour = lighten(G.C.JOKER_GREY, 0.5), r = 0.1, padding = 0.05, emboss = 0.05}, nodes={

--- a/CardSleeves.lua
+++ b/CardSleeves.lua
@@ -1556,7 +1556,7 @@ function G.UIDEF.sleeve_description(sleeve_key, minw, padding)
     minw = minw or 5.5
     padding = padding or 0
     local sleeve_center = CardSleeves.Sleeve:get_obj(sleeve_key)
-    local ret_nodes, full_UI_table = {}, {no_styled_name = true}
+    local ret_nodes, full_UI_table = {}, { no_styled_name = true }
     local sleeve_name = ""
     if sleeve_center then
         sleeve_center.generate_ui(create_fake_sleeve(sleeve_center), {}, nil, ret_nodes, nil, full_UI_table)
@@ -2208,7 +2208,7 @@ function Card:hover()
             end
         end
 
-        local ret_nodes, full_UI_table = {}, {}
+        local ret_nodes, full_UI_table = {}, { no_styled_name = true }
         sleeve_center.generate_ui(fake_sleeve_center, {}, nil, ret_nodes, nil, full_UI_table)
         local sleeve_name = full_UI_table.name or ret_nodes.name or "NAME ERROR"
         local desc_t = {}


### PR DESCRIPTION
Fixes orphaned text that appears in latest SMODS

In the places the mod called `generate_ui` to just obtain the name it has been replaced with a new local function that gets the localized `name_text` directly, to avoid any side effects on calls to generate_ui in general.

For the places it gets both the name and the description it uses a new flag to stop it from generating the orphan dynatext.

Ideally I wanted to allow Sleeves to be able to have formatted names like other centers (which is the point of the SMODS feature that caused this problem) but SMODS assumes things about the UI that are not true for the places Cardsleeves displays the text in (especially since Sleeves are almost always 'fake' cards). I will probably be PRing a way to allow name formatting for sleeves in the future but I didn't want to wait to finish that to fix this issue